### PR TITLE
Added the 'name' property to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,9 @@ io.normalize("A0"); // 14
 
 - This is the pin address for the board's default, built-in led.
 
+#### name
 
+- A printable version of the name of the IO plugin being used, e.g. "Raspi IO"
 
 ### TODO
 


### PR DESCRIPTION
As part of my work on [Abstract IO](http://github.com/nebrius/abstract-io), I noticed that the `name` property on IO plugins isn't defined in the docs. This PR adds the `name` property