### PR TITLE
Added HIGH and LOW values

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ The plugin must...
                 - OUTPUT mode: property updated via *Write methods
             - `report`: 1 if reporting, 0 if not reporting
             - `analogChannel`: corresponding analogPin index (127 if none), eg. `analogChannel: 0` is `A0` whose index is `14` in the `pins` array.
-    - include a readonly property named `analogPins` whose value is an array of pin indices that correspond to the analog pin indices in the `pins` array. 
+    - include a readonly property named `analogPins` whose value is an array of pin indices that correspond to the analog pin indices in the `pins` array.
+    - include a readonly property named `HIGH` whose value corresponds to the logic high value used by the IO plugin, e.g. `1`
+    - include a readonly property named `LOW` whose value corresponds to the logic low value used by the IO plugin, e.g. `0`
 - If an essential IO feature is not implemented or _cannot_ be implemented, the method _must_ throw. For example, the Raspberry Pi does not support analog inputs, if user code calls through to an `analogRead`, the program must throw as an irrefutable means of indicating non-support.
 - If a non-essential IO feature is not implemented or _cannot_ be implemented, the method _must_ accept the expected arguments and indicate successful completion. For example, if it receives a callback, that callback _must_ be called asynchronously.
 


### PR DESCRIPTION
As more part of my work on Abstract IO, I noticed that the `HIGH` and `LOW` properties on IO plugins aren't defined in the docs. This PR adds them.